### PR TITLE
Add simple Markov chatbot with CLI and GitHub Pages UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Improvised Language Learner
+
+This project contains a deliberately simple AI that starts by babbling
+nonsense and gradually learns from every human interaction it records. All
+conversations are stored in `data/conversations.json`, so history is versioned
+alongside the code.
+
+Two interfaces are included:
+
+- **Terminal chat (`python chat.py`)** – talk to the learner locally. Every
+  message is appended to the JSON log.
+- **GitHub Pages chat (`docs/index.html`)** – host a lightweight web UI that can
+  fetch and update the same conversation file through the GitHub REST API.
+
+## Getting started
+
+1. Install Python 3.9+.
+2. Create a virtual environment (optional) and install requirements (none are
+   needed beyond the standard library).
+3. Run the CLI: `python chat.py`.
+4. Type messages. The bot will reply using a Markov chain built from the stored
+   history. Type `/quit` or press <kbd>Ctrl</kbd>+<kbd>D</kbd> to exit.
+
+### Conversation log format
+
+`data/conversations.json` is a UTF-8 JSON file with a single key `messages`
+containing an array of objects:
+
+```json
+{
+  "speaker": "user" | "bot",
+  "text": "Message text",
+  "timestamp": "ISO-8601 UTC timestamp"
+}
+```
+
+The CLI and web UI both append to this list.
+
+## Deploying the web UI to GitHub Pages
+
+1. Commit the repository to GitHub.
+2. In repository settings, enable GitHub Pages and select the `docs/` folder.
+3. Visit the published site. Use the “Connect your repository” form to enter
+   the repository details and a personal access token with **contents:write**
+   scope (fine-grained tokens recommended).
+4. Start chatting! Every message triggers a GitHub API call that commits the
+   updated `data/conversations.json` back to the repository.
+
+> ⚠️ Never share or commit your personal access token. Users should supply
+> their own token when interacting with the hosted site.
+
+## Architecture overview
+
+- `src/learner.py` implements a small Markov-chain chatbot plus a
+  `ConversationStore` helper that reads/writes the JSON log.
+- `chat.py` offers a terminal interface that appends messages to the log.
+- `docs/` contains a static site (HTML/CSS/JS). The JavaScript re-implements the
+  same Markov logic in the browser and uses the GitHub REST API to load and
+  update the log file.
+
+## Development tips
+
+- The learner starts with gibberish until it sees enough tokens (16+) to model
+  English-like responses. Encourage friends to talk to it to improve its
+  vocabulary.
+- Use `--seed` when running `chat.py` if you want deterministic responses for
+  demos or tests.
+- Since every interaction is versioned, you can review conversation diffs and
+  roll back if necessary.

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,64 @@
+"""Command line chat interface for the Markov chatbot."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from src.learner import ConversationStore, MarkovChatbot
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interact with the improvised language learner.")
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path("data/conversations.json"),
+        help="Path to the JSON file where the conversation history is stored.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Optional random seed to make the bot deterministic for testing.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    store = ConversationStore(args.data)
+    bot = MarkovChatbot(store, seed=args.seed)
+
+    print("Welcome to the improvised language learner!")
+    print("Type '/quit' or press Ctrl+D to exit.\n")
+
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            print()  # newline after Ctrl+D
+            break
+        except KeyboardInterrupt:
+            print("\nGoodbye!")
+            return
+
+        if user_input.strip().lower() in {"/quit", "quit", "exit"}:
+            break
+        if not user_input.strip():
+            continue
+
+        try:
+            response = bot.respond(user_input)
+        except ValueError as exc:
+            print(f"[error] {exc}")
+            continue
+        print(f"Bot: {response}")
+
+    print(f"Conversation saved to {args.data}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/conversations.json
+++ b/data/conversations.json
@@ -1,0 +1,9 @@
+{
+  "messages": [
+    {
+      "speaker": "bot",
+      "text": "Glorm zibber faloo?",
+      "timestamp": "2024-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Improvised Language Learner</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Improvised Language Learner</h1>
+      <p>
+        This tiny AI begins with complete gibberish and slowly learns how people
+        talk by saving every interaction inside a GitHub repository. Connect it
+        to your repository, let people chat, and watch its vocabulary evolve.
+      </p>
+
+      <section>
+        <h2>Connect your repository</h2>
+        <form id="connect-form">
+          <label for="owner">Repository owner</label>
+          <input id="owner" name="owner" placeholder="octocat" required />
+
+          <label for="repo">Repository name</label>
+          <input id="repo" name="repo" placeholder="imlearning" required />
+
+          <label for="branch">Branch (defaults to <code>main</code>)</label>
+          <input id="branch" name="branch" placeholder="main" />
+
+          <label for="path">Conversation file (defaults to <code>data/conversations.json</code>)</label>
+          <input id="path" name="path" placeholder="data/conversations.json" />
+
+          <label for="token">GitHub personal access token (needed to save)</label>
+          <input
+            id="token"
+            name="token"
+            placeholder="ghp_…"
+            type="password"
+            autocomplete="off"
+          />
+
+          <p>
+            <strong>Security tip:</strong> create a fine-grained personal access
+            token with <em>contents: write</em> scope for this repository. Never
+            share or commit your token.
+          </p>
+
+          <button type="submit">Connect to GitHub</button>
+        </form>
+      </section>
+
+      <section id="chat-section" class="hidden">
+        <h2>Chat with the learner</h2>
+        <ul id="conversation"></ul>
+        <p id="history-summary">0 messages stored</p>
+        <form id="message-form">
+          <label for="message-input">Send a message</label>
+          <input id="message-input" placeholder="Say hello" autocomplete="off" />
+          <button type="submit">Send</button>
+        </form>
+        <p id="status-line">Connect to begin.</p>
+      </section>
+
+      <section>
+        <h2>Offline chat option</h2>
+        <p>
+          Prefer the terminal? Run <code>python chat.py</code> from this
+          repository. Every message is written to the same JSON log, so the web
+          UI and CLI stay in sync.
+        </p>
+      </section>
+
+      <section>
+        <h2>Publishing to GitHub Pages</h2>
+        <ol>
+          <li>Commit these files and push them to your GitHub repository.</li>
+          <li>Enable GitHub Pages and select the <code>docs/</code> folder as the site source.</li>
+          <li>
+            Share the GitHub Pages URL so anyone can open the chat, provide their
+            own token, and help the learner grow.
+          </li>
+        </ol>
+      </section>
+    </main>
+    <script type="module" src="scripts/app.js"></script>
+  </body>
+</html>

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -1,0 +1,212 @@
+import { MarkovLearner } from './learner.js';
+
+const connectForm = document.querySelector('#connect-form');
+const chatSection = document.querySelector('#chat-section');
+const messageList = document.querySelector('#conversation');
+const messageForm = document.querySelector('#message-form');
+const messageInput = document.querySelector('#message-input');
+const statusLine = document.querySelector('#status-line');
+const historySummary = document.querySelector('#history-summary');
+
+const learner = new MarkovLearner();
+let config = null;
+let conversation = { messages: [] };
+let fileSha = null;
+let isSaving = false;
+
+connectForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (isSaving) {
+    return;
+  }
+  const formData = new FormData(connectForm);
+  const owner = formData.get('owner').trim();
+  const repo = formData.get('repo').trim();
+  const branch = formData.get('branch').trim() || 'main';
+  const path = formData.get('path').trim() || 'data/conversations.json';
+  const token = formData.get('token').trim();
+
+  if (!owner || !repo) {
+    setStatus('Repository owner and name are required.', true);
+    return;
+  }
+
+  config = { owner, repo, branch, path, token };
+  setStatus('Connecting to GitHub…');
+
+  try {
+    await loadConversation();
+    renderMessages();
+    chatSection.classList.remove('hidden');
+    setStatus('Connected. Start chatting!');
+  } catch (error) {
+    console.error(error);
+    setStatus(`Failed to load conversation: ${error.message}`, true);
+    chatSection.classList.add('hidden');
+  }
+});
+
+messageForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (!config) {
+    setStatus('Connect to a repository before chatting.', true);
+    return;
+  }
+  if (isSaving) {
+    return;
+  }
+  const text = messageInput.value.trim();
+  if (!text) {
+    return;
+  }
+
+  const timestamp = new Date().toISOString();
+  const userMessage = { speaker: 'user', text, timestamp };
+  conversation.messages.push(userMessage);
+  const reply = learner.nextReply(conversation.messages);
+  const botMessage = { speaker: 'bot', text: reply, timestamp: new Date().toISOString() };
+  conversation.messages.push(botMessage);
+  renderMessages();
+  messageInput.value = '';
+  setStatus('Saving conversation to GitHub…');
+
+  try {
+    await saveConversation();
+    setStatus('Conversation saved. Keep going!');
+  } catch (error) {
+    console.error(error);
+    // Revert the last two messages if the save failed.
+    conversation.messages.splice(-2, 2);
+    renderMessages();
+    setStatus(`Failed to save conversation: ${error.message}`, true);
+  }
+});
+
+async function loadConversation() {
+  if (!config) {
+    throw new Error('Not configured');
+  }
+  const headers = buildHeaders();
+  const url = buildContentsUrl();
+  const response = await fetch(url, { headers });
+  if (response.status === 404) {
+    conversation = { messages: [] };
+    fileSha = null;
+    setStatus('No existing conversation found. A new one will be created when you chat.');
+    renderMessages();
+    return;
+  }
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  const payload = await response.json();
+  fileSha = payload.sha;
+  const text = decodeBase64(payload.content);
+  try {
+    conversation = JSON.parse(text);
+  } catch (error) {
+    throw new Error('Conversation file is not valid JSON.');
+  }
+  if (!conversation.messages) {
+    conversation.messages = [];
+  }
+  renderMessages();
+}
+
+async function saveConversation() {
+  if (!config) {
+    throw new Error('Not configured');
+  }
+  if (!config.token) {
+    throw new Error('A GitHub personal access token is required to save changes.');
+  }
+  isSaving = true;
+  try {
+    const headers = buildHeaders(true);
+    const url = buildContentsUrl();
+    const content = JSON.stringify(conversation, null, 2) + '\n';
+    const body = {
+      message: 'Update conversation log via web chat',
+      content: encodeBase64(content),
+      branch: config.branch,
+    };
+    if (fileSha) {
+      body.sha = fileSha;
+    }
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    const payload = await response.json();
+    fileSha = payload.content?.sha ?? null;
+  } finally {
+    isSaving = false;
+  }
+}
+
+function renderMessages() {
+  messageList.innerHTML = '';
+  conversation.messages.forEach((message) => {
+    const item = document.createElement('li');
+    item.className = `message message-${message.speaker}`;
+    const header = document.createElement('div');
+    header.className = 'message-meta';
+    const speaker = message.speaker === 'bot' ? 'Learner' : 'You';
+    header.textContent = `${speaker} • ${new Date(message.timestamp).toLocaleString()}`;
+    const text = document.createElement('div');
+    text.className = 'message-text';
+    text.textContent = message.text;
+    item.appendChild(header);
+    item.appendChild(text);
+    messageList.appendChild(item);
+  });
+  historySummary.textContent = `${conversation.messages.length} messages stored`;
+  messageList.scrollTop = messageList.scrollHeight;
+}
+
+function buildContentsUrl() {
+  const { owner, repo, path, branch } = config;
+  const encodedPath = path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodedPath}?ref=${encodeURIComponent(branch)}`;
+}
+
+function buildHeaders(includeToken = false) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+  };
+  const token = includeToken ? config.token : config.token || '';
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  headers['X-GitHub-Api-Version'] = '2022-11-28';
+  return headers;
+}
+
+function setStatus(message, isError = false) {
+  statusLine.textContent = message;
+  statusLine.classList.toggle('error', Boolean(isError));
+}
+
+function decodeBase64(value) {
+  const binary = atob(value.replace(/\n/g, ''));
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+
+function encodeBase64(value) {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(value);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}

--- a/docs/scripts/learner.js
+++ b/docs/scripts/learner.js
@@ -1,0 +1,106 @@
+const TOKEN_PATTERN = /[A-Za-z']+|\d+|[.,!?]/g;
+const GIBBERISH_SYLLABLES = [
+  'za',
+  'gru',
+  'plo',
+  'fen',
+  'zib',
+  'vor',
+  'quar',
+  'nib',
+  'mal',
+  'tre',
+];
+
+export class MarkovLearner {
+  constructor(rng = Math.random) {
+    this.rng = rng;
+  }
+
+  nextReply(messages) {
+    const tokens = messages.flatMap((message) => tokenize(message.text));
+    if (tokens.length < 16) {
+      return gibberish(this.rng);
+    }
+    const chain = buildChain(tokens);
+    return composeSentence(chain, tokens, this.rng);
+  }
+}
+
+export function tokenize(text) {
+  if (!text) {
+    return [];
+  }
+  return (text.toLowerCase().match(TOKEN_PATTERN) ?? []);
+}
+
+function buildChain(tokens) {
+  const transitions = new Map();
+  for (let i = 0; i < tokens.length - 1; i += 1) {
+    const current = tokens[i];
+    const next = tokens[i + 1];
+    if (!transitions.has(current)) {
+      transitions.set(current, []);
+    }
+    transitions.get(current).push(next);
+  }
+  return transitions;
+}
+
+function composeSentence(chain, corpusTokens, rng) {
+  if (!corpusTokens.length) {
+    return gibberish(rng);
+  }
+  const start = corpusTokens[Math.floor(rng() * corpusTokens.length)];
+  const length = Math.floor(rng() * 15) + 6; // 6 to 20 words
+  const words = [start];
+  for (let i = 1; i < length; i += 1) {
+    const options = chain.get(words[words.length - 1]);
+    if (!options || options.length === 0) {
+      break;
+    }
+    const choice = options[Math.floor(rng() * options.length)];
+    words.push(choice);
+  }
+  let sentence = formatSentence(words);
+  if (!sentence.endsWith('.') && !sentence.endsWith('!') && !sentence.endsWith('?')) {
+    sentence += '.';
+  }
+  return sentence;
+}
+
+function gibberish(rng) {
+  const wordCount = Math.floor(rng() * 5) + 3; // 3 to 7 words
+  const words = [];
+  for (let i = 0; i < wordCount; i += 1) {
+    const syllables = Math.floor(rng() * 3) + 2; // 2 to 4 syllables
+    let word = '';
+    for (let s = 0; s < syllables; s += 1) {
+      const choice = GIBBERISH_SYLLABLES[Math.floor(rng() * GIBBERISH_SYLLABLES.length)];
+      word += choice;
+    }
+    words.push(word);
+  }
+  let sentence = words.join(' ');
+  sentence = sentence.charAt(0).toUpperCase() + sentence.slice(1);
+  const endings = ['?', '!', '...'];
+  sentence += endings[Math.floor(rng() * endings.length)];
+  return sentence;
+}
+
+function formatSentence(tokens) {
+  if (!tokens.length) {
+    return '';
+  }
+  let sentence = tokens[0];
+  for (let i = 1; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (['.', ',', '!', '?'].includes(token)) {
+      sentence += token;
+    } else {
+      sentence += ` ${token}`;
+    }
+  }
+  sentence = sentence.charAt(0).toUpperCase() + sentence.slice(1);
+  return sentence;
+}

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -1,0 +1,129 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #0f172a;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  min-height: 100%;
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2.5rem;
+  text-align: center;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 1rem 3rem rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+form label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+form input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  margin-bottom: 1rem;
+}
+
+form button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.5rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+form button:hover {
+  filter: brightness(1.05);
+}
+
+#chat-section.hidden {
+  display: none;
+}
+
+#conversation {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 400px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(30, 64, 175, 0.35);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  backdrop-filter: blur(6px);
+}
+
+.message-user {
+  align-self: flex-end;
+  background: rgba(14, 116, 144, 0.4);
+  border-color: rgba(45, 212, 191, 0.3);
+}
+
+.message-meta {
+  font-size: 0.75rem;
+  opacity: 0.8;
+  margin-bottom: 0.4rem;
+}
+
+.message-text {
+  font-size: 1rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+#history-summary {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+#status-line {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+#status-line.error {
+  color: #facc15;
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 1.5rem 1rem 3rem;
+  }
+}

--- a/src/learner.py
+++ b/src/learner.py
@@ -1,0 +1,165 @@
+"""Simple conversational learner that stores dialogues in JSON."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+# Regular expression to split text into word-like tokens while keeping punctuation.
+_TOKEN_PATTERN = re.compile(r"[A-Za-z']+|\d+|[.,!?]")
+
+
+@dataclass
+class Message:
+    """Represents a single utterance in the conversation log."""
+
+    speaker: str
+    text: str
+    timestamp: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"speaker": self.speaker, "text": self.text, "timestamp": self.timestamp}
+
+
+class ConversationStore:
+    """Handles loading and saving conversation history to a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            try:
+                data = json.loads(self.path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+                raise ValueError(f"Conversation file {self.path} is not valid JSON") from exc
+        else:
+            data = {"messages": []}
+            self._write(data)
+        self._messages: List[Message] = [
+            Message(**message) for message in data.get("messages", []) if _validate_message(message)
+        ]
+
+    @property
+    def messages(self) -> Sequence[Message]:
+        return tuple(self._messages)
+
+    def append(self, speaker: str, text: str) -> Message:
+        message = Message(speaker=speaker, text=text, timestamp=_current_timestamp())
+        self._messages.append(message)
+        self._write({"messages": [msg.as_dict() for msg in self._messages]})
+        return message
+
+    def _write(self, payload: Dict[str, Iterable[Dict[str, str]]]) -> None:
+        self.path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+class MarkovChatbot:
+    """A tiny chatbot that learns a Markov model from prior conversation."""
+
+    def __init__(self, store: ConversationStore, seed: int | None = None) -> None:
+        self.store = store
+        self.random = random.Random(seed)
+
+    def respond(self, user_text: str) -> str:
+        user_text = user_text.strip()
+        if not user_text:
+            raise ValueError("Cannot learn from empty user input.")
+        self.store.append("user", user_text)
+        reply = self._generate_reply()
+        self.store.append("bot", reply)
+        return reply
+
+    def _generate_reply(self) -> str:
+        messages = self.store.messages
+        tokens = [token for message in messages for token in _tokenize(message.text)]
+        if len(tokens) < 16:
+            return _gibberish(self.random)
+        chain = _build_chain(tokens)
+        return _compose_sentence(chain, tokens, self.random)
+
+
+def _validate_message(message: Dict[str, str]) -> bool:
+    return {
+        "speaker",
+        "text",
+        "timestamp",
+    }.issubset(message)
+
+
+def _current_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _tokenize(text: str) -> List[str]:
+    return [match.group(0).lower() for match in _TOKEN_PATTERN.finditer(text)]
+
+
+def _build_chain(tokens: Sequence[str]) -> Dict[str, List[str]]:
+    transitions: Dict[str, List[str]] = {}
+    for current, nxt in zip(tokens, tokens[1:]):
+        transitions.setdefault(current, []).append(nxt)
+    return transitions
+
+
+def _compose_sentence(chain: Dict[str, List[str]], corpus_tokens: Sequence[str], rng: random.Random) -> str:
+    if not corpus_tokens:
+        return _gibberish(rng)
+    start = rng.choice(corpus_tokens)
+    length = rng.randint(6, 20)
+    words = [start]
+    for _ in range(length - 1):
+        options = chain.get(words[-1])
+        if not options:
+            break
+        words.append(rng.choice(options))
+    sentence = _format_sentence(words)
+    if sentence[-1] not in ".!?":
+        sentence += "."
+    return sentence
+
+
+_GIBBERISH_SYLLABLES = [
+    "za",
+    "gru",
+    "plo",
+    "fen",
+    "zib",
+    "vor",
+    "quar",
+    "nib",
+    "mal",
+    "tre",
+]
+
+
+def _gibberish(rng: random.Random) -> str:
+    word_count = rng.randint(3, 7)
+    words = []
+    for _ in range(word_count):
+        syllables = rng.randint(2, 4)
+        word = "".join(rng.choice(_GIBBERISH_SYLLABLES) for _ in range(syllables))
+        words.append(word)
+    sentence = " ".join(words)
+    sentence = sentence.capitalize()
+    sentence += rng.choice(["?", "!", "..."])
+    return sentence
+
+
+def _format_sentence(tokens: Sequence[str]) -> str:
+    if not tokens:
+        return ""
+    sentence = tokens[0]
+    for token in tokens[1:]:
+        if token in {".", ",", "!", "?"}:
+            sentence += token
+        else:
+            sentence += " " + token
+    return sentence.capitalize()
+
+
+__all__ = ["ConversationStore", "MarkovChatbot", "Message"]


### PR DESCRIPTION
## Summary
- implement a JSON-backed conversation store and Markov learner that starts with gibberish
- add a CLI chat script that appends interactions to the shared log
- build a GitHub Pages-ready web UI that commits conversations through the GitHub API

## Testing
- python chat.py --data data/test_convo.json --seed 123
- python -m compileall src chat.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcd8437c0833380f67b4135e64a34